### PR TITLE
runAsync()

### DIFF
--- a/sdl_exp/visualisation/Visualisation.cpp
+++ b/sdl_exp/visualisation/Visualisation.cpp
@@ -163,6 +163,7 @@ void Visualisation::handleKeypress(SDL_Keycode keycode, int x, int y){
     }
 }
 void Visualisation::close(){
+	killThread();
 	assert(this->window);//There should always be a window, it might just be hidden
 	SDL_GL_MakeCurrent(this->window, this->context);
     //Delete objects before we delete the GL context!

--- a/sdl_exp/visualisation/Visualisation.cpp
+++ b/sdl_exp/visualisation/Visualisation.cpp
@@ -28,16 +28,17 @@
 #define DEFAULT_WINDOW_HEIGHT 720
 
 Visualisation::Visualisation(char *windowTitle, int windowWidth = DEFAULT_WINDOW_WIDTH, int windowHeight = DEFAULT_WINDOW_HEIGHT)
-    : hud(windowWidth, windowHeight)
+    : t(nullptr)
+    , hud(windowWidth, windowHeight)
     , camera(glm::vec3(50,50,50))
     , scene(nullptr)
     , isInitialised(false)
-    , continueRender(true)
-	, msaaState(true)
+	, continueRender(false)
+    , msaaState(true)
     , windowTitle(windowTitle)
     , windowWidth(windowWidth)
     , windowHeight(windowHeight)
-    , fpsDisplay(0)
+	, fpsDisplay(nullptr)
 {
     this->isInitialised = this->init();
 
@@ -51,10 +52,12 @@ Visualisation::Visualisation(char *windowTitle, int windowWidth = DEFAULT_WINDOW
 }
 Visualisation::~Visualisation()
 {
+	this->close();
 }
 bool Visualisation::init(){
     SDL_Init(SDL_INIT_VIDEO);
 
+	SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
     // Enable MSAA (Must occur before SDL_CreateWindow)
     SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
     SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 8);
@@ -79,8 +82,8 @@ bool Visualisation::init(){
         SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL //| SDL_WINDOW_BORDERLESS
         );
 
-    if (this->window == NULL){
-        printf("window failed to init");
+    if (!this->window){
+        printf("Window failed to init.\n");
     }
     else {
         SDL_GetWindowPosition(window, &this->windowedBounds.x, &this->windowedBounds.y);
@@ -160,6 +163,8 @@ void Visualisation::handleKeypress(SDL_Keycode keycode, int x, int y){
     }
 }
 void Visualisation::close(){
+	assert(this->window);//There should always be a window, it might just be hidden
+	SDL_GL_MakeCurrent(this->window, this->context);
     //Delete objects before we delete the GL context!
     fpsDisplay.reset();
 	helpText.reset();
@@ -167,10 +172,10 @@ void Visualisation::close(){
     if (this->scene)
     {
         this->scene.reset();
-    }
+	}
+	SDL_DestroyWindow(this->window);
+	this->window = nullptr;
     SDL_GL_DeleteContext(this->context);
-    SDL_DestroyWindow(this->window);
-    this->window = nullptr;
     SDL_Quit();
 }
 void Visualisation::render()
@@ -258,28 +263,81 @@ void Visualisation::render()
     // update the screen
     SDL_GL_SwapWindow(window);
 }
-void Visualisation::run(){
+void Visualisation::runAsync()
+{
+	if (!t&&!continueRender)
+	{
+		//Curiously, if we destroy a host-thread window from a different thread, the glContext breaks
+		//However the inverse is not true
+		SDL_GL_MakeCurrent(this->window, NULL);
+		SDL_DestroyWindow(this->window);
+		this->window = nullptr;
+		this->t = new std::thread(&Visualisation::_run, this);
+	}
+	else
+	{
+		printf("Already running! Call quit() to close it first!\n");
+	}
+}
+void Visualisation::run()
+{
+	if (!t&&!continueRender)
+	{
+		_run();
+	}
+	else
+	{
+		printf("Already running! Call quit() to close it first!\n");
+	}
+}
+void Visualisation::_run()
+{
     if (!this->isInitialised){
-        printf("Visulisation not initialised yet.");
+        printf("Visulisation not initialised yet.\n");
     }
     else if (!this->scene){
-        printf("Scene not yet set.");
+        printf("Scene not yet set.\n");
     }
-    else {
-        SDL_ShowWindow(this->window);
-        SDL_StartTextInput();
-        this->continueRender = true;
-        while (this->continueRender){
-            // Update the fps in the window title
-            this->updateFPS();
+	else {
+		//Recreate window in current thread (else IO fails)
+		if (this->window)
+		{
+			SDL_GL_MakeCurrent(this->window, NULL);
+			SDL_DestroyWindow(this->window);
+		}
+		this->window = SDL_CreateWindow
+		(
+			this->windowTitle,
+			this->windowedBounds.x,
+			this->windowedBounds.y,
+			this->windowedBounds.w,
+			this->windowedBounds.h,
+			SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL //| SDL_WINDOW_BORDERLESS
+		);
+		if (!this->window){
+			printf("Window failed to init.\n");
+		}
+		else {
+			SDL_GL_MakeCurrent(this->window, this->context);
+			this->resizeWindow();
+			GL_CHECK();
+			SDL_StartTextInput();
+			this->continueRender = true;
+			while (this->continueRender){
+				// Update the fps in the window title
+				this->updateFPS();
 
-            this->render();
-        }
-        SDL_StopTextInput();
-
+				this->render();
+			}
+			SDL_StopTextInput();
+			//Release mouse lock
+			if (SDL_GetRelativeMouseMode()){
+				SDL_SetRelativeMouseMode(SDL_FALSE);
+			}
+			//Hide window
+			SDL_HideWindow(window);
+		}
     }
-
-    this->close();
 }
 void Visualisation::setMSAA(bool state){
     this->msaaState = state;
@@ -296,7 +354,27 @@ void Visualisation::setWindowTitle(const char *windowTitle){
     SDL_SetWindowTitle(this->window, this->windowTitle);
 }
 void Visualisation::quit(){
-    this->continueRender = false;
+	this->continueRender = false;
+	if (this->t)
+	{
+		//Wait for thread to exit
+		this->t->join();
+		delete this->t;
+		this->t = nullptr;
+		//Recreate hidden window in current thread, so context is stable
+		SDL_GL_MakeCurrent(this->window, NULL);
+		SDL_DestroyWindow(this->window);
+		this->window = SDL_CreateWindow
+			(
+			this->windowTitle,
+			this->windowedBounds.x,
+			this->windowedBounds.y,
+			this->windowedBounds.w,
+			this->windowedBounds.h,
+			SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL //| SDL_WINDOW_BORDERLESS
+			);
+		SDL_GL_MakeCurrent(this->window, this->context);
+	}
 }
 void Visualisation::toggleFullScreen(){
     if (this->isFullscreen()){

--- a/sdl_exp/visualisation/Visualisation.h
+++ b/sdl_exp/visualisation/Visualisation.h
@@ -168,6 +168,10 @@ private:
 	 * Internal run method, allows us to avoid starting the render loop if it's already executing when run() or runAsync() are called
 	 */
 	void _run();
+	/**
+	 * Kills thread t, only to be called from host threead.
+	 */
+	void killThread();
 	std::thread *t;
     SDL_Window* window;
     SDL_Rect windowedBounds;

--- a/sdl_exp/visualisation/Visualisation.h
+++ b/sdl_exp/visualisation/Visualisation.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include "Camera.h"
 #include "HUD.h"
+#include <thread>
+#include <atomic>
 
 #undef main //SDL breaks the regular main entry point, this fixes
 
@@ -46,9 +48,18 @@ public:
 	/**
 	 * Executes the render loop, this is a blocking call
      * @see quit() to externally kill the loop
-     * @todo Make a runAsync() method
 	 */
 	void run();
+	/**
+	 * Executes the redner loop in an asynchronous background thread
+     * @see quit() to externally kill the loop
+	 */
+	void runAsync();
+	/**
+	 * Returns whether the window is currently rendering
+	 * @note This may report false early if the rendering is in the process of exiting
+	 */
+	bool isRunning() const { return continueRender; }
 	/**
 	 * @return The current window title
 	 */
@@ -75,10 +86,6 @@ public:
 	 * Toggles whether the mouse is hidden and returned relative to the window
 	 */
     void toggleMouseMode();
-	/**
-	 * Loads the ModelView and Projection matrices using the old fixed function pipeline methods
-	 */
-	void defaultProjection();
 	/**
 	 * Toggles whether Multi-Sample Anti-Aliasing should be used or not
 	 * @param state The desired MSAA state
@@ -157,7 +164,11 @@ private:
 	 * Provides destruction of the object, deletes child objects, removes the GL context, closes the window and calls SDL_quit()
 	 */
     void close();
-
+	/**
+	 * Internal run method, allows us to avoid starting the render loop if it's already executing when run() or runAsync() are called
+	 */
+	void _run();
+	std::thread *t;
     SDL_Window* window;
     SDL_Rect windowedBounds;
     SDL_GLContext context;
@@ -167,8 +178,8 @@ private:
 	std::shared_ptr<Scene> scene;
     glm::mat4 frustum;
 
-    bool isInitialised;
-    bool continueRender;
+	bool isInitialised;
+	std::atomic<bool> continueRender;
 
     bool msaaState;
 


### PR DESCRIPTION
Adjusted `Visualisation` to always maintain a hidden window at all times (this a requirement to have an active GLContext by SDL2 [apparently GL3+ don't require a window for a GLContext]).

Not tested what happens if SDL methods that affect the window are called from a different thread (aka MSAA).

Nuance learned from this work;

* If you close the SDL window that created the context in a different thread to that it was created, shit breaks. This doesn't seem to apply for tertiary windows created elsewhere.

* If you fail to destroy a window, subsequent windows won't receive events, such as clicking cross in the corner.