### PR TITLE
Created OOP Buffers

### DIFF
--- a/sdl_exp/sdl_exp.vcxproj
+++ b/sdl_exp/sdl_exp.vcxproj
@@ -174,6 +174,9 @@
     <ClCompile Include="visualisation\multipass\MultiPassScene.cpp" />
     <ClCompile Include="visualisation\multipass\RenderPass.cpp" />
     <ClCompile Include="visualisation\Overlay.cpp" />
+    <ClCompile Include="visualisation\shader\buffer\BufferCore.cpp" />
+    <ClCompile Include="visualisation\shader\buffer\ShaderStorageBuffer.cpp" />
+    <ClCompile Include="visualisation\shader\buffer\UniformBuffer.cpp" />
     <ClCompile Include="visualisation\shader\ComputeShader.cpp" />
     <ClCompile Include="visualisation\shader\GaussianBlur.cpp" />
     <ClCompile Include="visualisation\shader\ShaderCore.cpp" />
@@ -214,6 +217,9 @@
     <ClInclude Include="visualisation\multipass\MultiPassScene.h" />
     <ClInclude Include="visualisation\multipass\RenderPass.h" />
     <ClInclude Include="visualisation\Overlay.h" />
+    <ClInclude Include="visualisation\shader\buffer\BufferCore.h" />
+    <ClInclude Include="visualisation\shader\buffer\ShaderStorageBuffer.h" />
+    <ClInclude Include="visualisation\shader\buffer\UniformBuffer.h" />
     <ClInclude Include="visualisation\shader\ComputeShader.h" />
     <ClInclude Include="visualisation\shader\GaussianBlur.h" />
     <ClInclude Include="visualisation\shader\ShaderCore.h" />

--- a/sdl_exp/sdl_exp.vcxproj.filters
+++ b/sdl_exp/sdl_exp.vcxproj.filters
@@ -48,6 +48,12 @@
     <Filter Include="Source Files\Visualisation\Util">
       <UniqueIdentifier>{561a15bc-295a-46ca-a632-3ba1da2d012d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Visualisation\Shader\Buffer">
+      <UniqueIdentifier>{6bff0996-7c58-483b-8f91-c771ccf1b11e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Visualisation\Shader\Buffer">
+      <UniqueIdentifier>{fa904b7b-5604-4ee4-9ca2-2aefd0495c65}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="visualisation\Axis.cpp">
@@ -130,6 +136,15 @@
     </ClCompile>
     <ClCompile Include="visualisation\util\Optimus.cpp">
       <Filter>Source Files\Visualisation\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="visualisation\shader\buffer\BufferCore.cpp">
+      <Filter>Source Files\Visualisation\Shader\Buffer</Filter>
+    </ClCompile>
+    <ClCompile Include="visualisation\shader\buffer\ShaderStorageBuffer.cpp">
+      <Filter>Source Files\Visualisation\Shader\Buffer</Filter>
+    </ClCompile>
+    <ClCompile Include="visualisation\shader\buffer\UniformBuffer.cpp">
+      <Filter>Source Files\Visualisation\Shader\Buffer</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -233,6 +248,15 @@
     </ClInclude>
     <ClInclude Include="visualisation\util\GLcheck.h">
       <Filter>Header Files\Visualisation\Util</Filter>
+    </ClInclude>
+    <ClInclude Include="visualisation\shader\buffer\ShaderStorageBuffer.h">
+      <Filter>Header Files\Visualisation\Shader\Buffer</Filter>
+    </ClInclude>
+    <ClInclude Include="visualisation\shader\buffer\UniformBuffer.h">
+      <Filter>Header Files\Visualisation\Shader\Buffer</Filter>
+    </ClInclude>
+    <ClInclude Include="visualisation\shader\buffer\BufferCore.h">
+      <Filter>Header Files\Visualisation\Shader\Buffer</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/sdl_exp/visualisation/shader/GaussianBlur.cpp
+++ b/sdl_exp/visualisation/shader/GaussianBlur.cpp
@@ -3,54 +3,51 @@
 
 
 GaussianBlur::GaussianBlur(unsigned int filterRadius, float sigma)
-    : sigma(sigma)
-    , filterRadius(glm::clamp<unsigned int>(filterRadius, 0, 16))
-    , filterWidth(2 * glm::clamp<unsigned int>(filterRadius, 0, 16) + 1)
-    , blurShader(std::make_shared<ComputeShader>(GAUSSIAN_BLUR_SHADER_PATH))
-    , filter(nullptr)
+	: sigma(sigma)
+	, filterRadius(glm::clamp<unsigned int>(filterRadius, 0, 16))
+	, filterWidth(2 * glm::clamp<unsigned int>(filterRadius, 0, 16) + 1)
+	, blurShader(std::make_shared<ComputeShader>(GAUSSIAN_BLUR_SHADER_PATH))
+	, filter(nullptr)
 {
-    if (filterRadius != this->filterRadius)
-        fprintf(stderr, "Gaussian filter radius was clamped from %d to %d.\n", filterRadius, this->filterRadius);
-    //For the time being we will allocate ourselves the final 2 image units
-    this->inBufferBind = 0;
-    this->outBufferBind = 1;
-    //Generate the Gaussian filter (manually at current)
-    this->filter = (float*)malloc(filterWidth*sizeof(float));
-    generateFilter();
-    //Copy that to a uniform buffer
-    GL_CALL(glGenBuffers(1, &this->filterBuffer));
-    GL_CALL(glBindBuffer(GL_UNIFORM_BUFFER, this->filterBuffer));
-    GL_CALL(glBufferData(GL_UNIFORM_BUFFER, filterWidth*sizeof(float), this->filter, GL_STATIC_READ));
-    GL_CALL(glBindBuffer(GL_UNIFORM_BUFFER, 0));
-    //Configure uniforms
-    blurShader->addBuffer("_filterWeights", GL_UNIFORM_BUFFER, this->filterBuffer);
-    blurShader->addStaticUniform("_filterRadius", &this->filterRadius);
-    blurShader->addStaticUniform("_filterWidth", &this->filterWidth);
-    blurShader->addStaticUniform("_imageIn", &this->inBufferBind);
-    blurShader->addStaticUniform("_imageOut", &this->outBufferBind);
-    blurShader->addDynamicUniform("_imageDimensions", glm::value_ptr(this->imageDimensions), 2);
+	if (filterRadius != this->filterRadius)
+		fprintf(stderr, "Gaussian filter radius was clamped from %d to %d.\n", filterRadius, this->filterRadius);
+	//For the time being we will allocate ourselves the final 2 image units
+	this->inBufferBind = 0;
+	this->outBufferBind = 1;
+	//Generate the Gaussian filter (manually at current)
+	this->filter = (float*)malloc(filterWidth*sizeof(float));
+	generateFilter();
+	//Copy that to a uniform buffer
+	filterBuffer = std::make_shared<UniformBuffer>(filterWidth*sizeof(float), this->filter);
+	//Configure uniforms
+	blurShader->addBuffer("_filterWeights", this->filterBuffer);
+	blurShader->addStaticUniform("_filterRadius", &this->filterRadius);
+	blurShader->addStaticUniform("_filterWidth", &this->filterWidth);
+	blurShader->addStaticUniform("_imageIn", &this->inBufferBind);
+	blurShader->addStaticUniform("_imageOut", &this->outBufferBind);
+	blurShader->addDynamicUniform("_imageDimensions", glm::value_ptr(this->imageDimensions), 2);
 }
 GaussianBlur::~GaussianBlur()
 {
-    GL_CALL(glDeleteBuffers(1, &this->filterBuffer));
-    free(filter);
+	this->filterBuffer.reset();
+	free(filter);
 }
 void GaussianBlur::generateFilter()
 {//http://www.stat.wisc.edu/~mchung/teaching/MIA/reading/diffusion.gaussian.kernel.pdf.pdf
 	//Count filter, so it can be normalised
 	float c = 0.0f;
-    //Fill filter without sigma
-    //unsigned int i = 0;
-    //for (unsigned int x = 0; x < filterWidth; ++x)
-    //{
-    //    filter[x] = (float)(x <= filterRadius ? ++i : --i);
-    //    c += filter[x];
-    //}
+	//Fill filter without sigma
+	//unsigned int i = 0;
+	//for (unsigned int x = 0; x < filterWidth; ++x)
+	//{
+	//    filter[x] = (float)(x <= filterRadius ? ++i : --i);
+	//    c += filter[x];
+	//}
 	//Fill filter with sigma
 	int i = filterRadius;
 	for (unsigned int x = 0; x < filterWidth; ++x)
 	{
-		float _j = (x < filterRadius ? i-- : i++);
+		float _j = (float)(x < filterRadius ? i-- : i++);
 		filter[x] = (1.0f / (sqrt(2.0f*glm::pi<float>())*this->sigma))*glm::exp(-(_j*_j) / (2 * this->sigma*this->sigma));
 		c += filter[x];
 	}
@@ -62,16 +59,16 @@ void GaussianBlur::generateFilter()
 }
 void GaussianBlur::blurR32F(GLuint inTex, GLuint outTex, glm::uvec2 texDims)
 {
-    //Update shader config
-    this->imageDimensions = texDims;
-    blurShader->useProgram();
-    GL_CALL(glBindImageTexture(this->inBufferBind, inTex, 0, GL_FALSE, 0, GL_READ_ONLY, GL_R32F));
-    GL_CALL(glBindImageTexture(this->outBufferBind, outTex, 0, GL_FALSE, 0, GL_WRITE_ONLY, GL_R32F));
-    blurShader->launch((texDims / glm::uvec2(16)) + glm::uvec2(1));
-    //Synchronise written memory
-    glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+	//Update shader config
+	this->imageDimensions = texDims;
+	blurShader->useProgram();
+	GL_CALL(glBindImageTexture(this->inBufferBind, inTex, 0, GL_FALSE, 0, GL_READ_ONLY, GL_R32F));
+	GL_CALL(glBindImageTexture(this->outBufferBind, outTex, 0, GL_FALSE, 0, GL_WRITE_ONLY, GL_R32F));
+	blurShader->launch((texDims / glm::uvec2(16)) + glm::uvec2(1));
+	//Synchronise written memory
+	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 }
 void GaussianBlur::reload()
 {
-    blurShader->reload();
+	blurShader->reload();
 }

--- a/sdl_exp/visualisation/shader/GaussianBlur.h
+++ b/sdl_exp/visualisation/shader/GaussianBlur.h
@@ -1,6 +1,7 @@
 #ifndef __GaussianBlur_h__
 #define __GaussianBlur_h__
 #include "ComputeShader.h"
+#include "buffer/UniformBuffer.h"
 #include <memory>
 
 /**
@@ -12,27 +13,27 @@
  */
 class GaussianBlur : public Reloadable
 {
-    const char *GAUSSIAN_BLUR_SHADER_PATH = "../shaders/gaussian_blur.comp";
+	const char *GAUSSIAN_BLUR_SHADER_PATH = "../shaders/gaussian_blur.comp";
 public:
-    /**
-     * Builds the compute shader and preconfigures the weights
-     */
+	/**
+	 * Builds the compute shader and preconfigures the weights
+	 */
 	GaussianBlur(unsigned int filterRadius, float sigma = 1.0f);
 	~GaussianBlur();
 	void blurR32F(GLuint inTex, GLuint outTex, glm::uvec2 texDims);
-    virtual void reload() override;
+	virtual void reload() override;
 private:
-    void generateFilter();
-    //These are mapped to the shader uniforms
-    const float sigma;
-    const unsigned int filterRadius;
-    const unsigned int filterWidth;
-    glm::uvec2 imageDimensions;
-    GLuint filterBuffer;
-    GLint inBufferBind;
-    GLint outBufferBind;
-    std::shared_ptr<ComputeShader> blurShader;
-    float *filter;
+	void generateFilter();
+	//These are mapped to the shader uniforms
+	const float sigma;
+	const unsigned int filterRadius;
+	const unsigned int filterWidth;
+	glm::uvec2 imageDimensions;
+	std::shared_ptr<UniformBuffer> filterBuffer;
+	GLint inBufferBind;
+	GLint outBufferBind;
+	std::shared_ptr<ComputeShader> blurShader;
+	float *filter;
 };
 
 #endif //__GaussianBlur_h__

--- a/sdl_exp/visualisation/shader/ShaderCore.cpp
+++ b/sdl_exp/visualisation/shader/ShaderCore.cpp
@@ -482,9 +482,9 @@ bool ShaderCore::addBuffer(const char *bufferNameInShader, const GLenum bufferTy
 	{
         //Get the uniform buffers index within the shader program
         GLenum blockType = getResourceBlock(bufferType);
-        if (blockType == GL_INVALID_ENUM)
+		if (blockType == GL_INVALID_ENUM)
             return false;
-        GLuint blockIndex = GL_CALL(glGetProgramResourceIndex(this->programId, blockType, bufferNameInShader));
+		GLuint blockIndex = GL_CALL(glGetProgramResourceIndex(this->programId, blockType, bufferNameInShader));
 		if (blockIndex != GL_INVALID_INDEX)
 		{
 			//Replace with new one

--- a/sdl_exp/visualisation/shader/ShaderCore.h
+++ b/sdl_exp/visualisation/shader/ShaderCore.h
@@ -8,6 +8,9 @@
 #include <list>
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
+#include <memory>
+
+class BufferCore;//Implementation of addBuffer(const char *, std::shared_ptr<BufferCore>) found in BufferCore.cpp
 
 /**
  * This class is is a wrapper for the core OpenGL shader operations
@@ -184,10 +187,20 @@ public:
 	 * If a buffer with the same bufferNameInShader is already bound, it will be replaced
 	 * This is for 'program resources', NOT texture buffers
 	 * @param bufferNameInShader The indentifier of the buffer within the shader source
-	 * @param bufferType The type of buffer (probably GL_SHADER_STORAGE_BUFFER)
+	 * @param bufferType The type of buffer (probably GL_SHADER_STORAGE_BUFFER or GL_UNIFORM_BUFFER)
 	 * @param bufferName The buffer name as set by glGenBuffers(GLsizei, GLuint)
 	 */
 	bool addBuffer(const char *bufferNameInShader, const GLenum bufferType, const GLuint bufferName);
+	/**
+	* Attatches the specified buffer to the shader if bufferNameInShader can be found
+	* If a buffer with the same bufferNameInShader is already bound, it will be replaced
+	* This is for 'program resources', NOT texture buffers
+	* This will not retain the shared_ptr, it's upto you to keep it alive
+	* @param bufferNameInShader The indentifier of the buffer within the shader source
+	* @param buffer The buffer to be used
+	* @note Convenience method, implemented in BufferCore.cpp
+	*/
+	bool addBuffer(const char *bufferNameInShader, std::shared_ptr<BufferCore> buffer);
 	/**
 	* Unbinds the named dynamic uniform
 	* @note This will not replace the value cached in the shader, reload() is necessary to achieve that

--- a/sdl_exp/visualisation/shader/ShaderCore.h
+++ b/sdl_exp/visualisation/shader/ShaderCore.h
@@ -373,13 +373,13 @@ private:
 		*/
 		const char* nameInShader;
 		/**
-		* The type of buffer (e.g. GL_SHADER_STORAGE_BUFFER)
+		* The type of buffer (e.g. GL_SHADER_STORAGE_BUFFER, GL_UNIFORM_BUFFER)
 		*/
 		const GLenum type;
 		/**
-		* The name of the buffer (as returned by glGenBuffers())
+		* The binding point of the buffer (as set with glBindBufferBase())
 		*/
-		const GLuint name;
+		const GLuint bindingPoint;
 	};
 	/**
 	* Holds additional information necessary for tracking buffers

--- a/sdl_exp/visualisation/shader/buffer/BufferCore.cpp
+++ b/sdl_exp/visualisation/shader/buffer/BufferCore.cpp
@@ -1,0 +1,161 @@
+#include "BufferCore.h"
+#include "../../util/GLcheck.h"
+#include <cassert>
+
+BufferCore::BufferCore(GLenum bufferType, GLint bindPoint, size_t size, void* data)
+	: size(size)
+	, bufferName(0)
+	, bufferBindPoint(bindPoint)
+	, bufferType(bufferType)
+{
+	assert(this->size < maxSize(bufferType));
+	GL_CALL(glGenBuffers(1, &bufferName));
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glBindBufferBase(bufferType, bufferBindPoint, bufferName));
+	GL_CALL(glBufferData(bufferType, size, data, GL_STATIC_DRAW));
+	GL_CALL(glBindBuffer(bufferType, 0));
+}
+BufferCore::~BufferCore()
+{
+	GL_CALL(glDeleteBuffers(1, &bufferName));
+}
+void BufferCore::setData(void *data, size_t size)
+{
+	this->size = size == 0 ? this->size : size;
+	assert(this->size < maxSize(bufferType));
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glBufferData(bufferType, this->size, data, GL_STATIC_DRAW));
+	GL_CALL(glBindBuffer(bufferType, 0));
+}
+void BufferCore::setData(void *data, size_t size, size_t offset){
+	assert(size + offset <= this->size);
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glBufferSubData(bufferType, offset, size, (void*)data));
+	GL_CALL(glBindBuffer(bufferType, 0));
+}
+void BufferCore::getData(void *dataReturn, size_t size, size_t offset)
+{
+	size = size == 0 ? this->size : size;
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glGetBufferSubData(bufferType, offset, size, (void*)dataReturn));
+	GL_CALL(glBindBuffer(bufferType, 0));
+}
+void const *BufferCore::mapBufferRead()
+{
+	return mapBuffer(GL_READ_ONLY);
+}
+void *BufferCore::mapBufferWrite()
+{
+	return mapBuffer(GL_WRITE_ONLY);
+}
+void *BufferCore::mapBufferReadWrite()
+{
+	return mapBuffer(GL_READ_WRITE);
+}
+void *BufferCore::mapBuffer(GLenum access)
+{
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glMapBuffer(bufferType, access));
+	GL_CALL(glBindBuffer(bufferType, 0));
+	void *rtn;
+	GL_CALL(glGetBufferPointerv(bufferType, GL_BUFFER_MAP_POINTER, &rtn));
+	return rtn;
+}
+void BufferCore::unmapBuffer()
+{
+	GL_CALL(glBindBuffer(bufferType, bufferName));
+	GL_CALL(glUnmapBuffer(bufferType));
+	GL_CALL(glBindBuffer(bufferType, 0));
+}
+GLenum BufferCore::getBlockType()
+{
+	if (bufferType == GL_UNIFORM_BUFFER)
+		return GL_UNIFORM_BLOCK;
+	else if (bufferType == GL_SHADER_STORAGE_BUFFER)
+		return GL_SHADER_STORAGE_BLOCK;
+	else if (bufferType == GL_TRANSFORM_FEEDBACK_BUFFER)
+		return GL_TRANSFORM_FEEDBACK_BUFFER;
+	else//(bufferType == GL_ATOMIC_COUNTER_BUFFER)
+	{
+		fprintf(stderr, "Buffer type was unexpected.\n");
+		return GL_INVALID_ENUM;
+	}
+}
+GLint BufferCore::maxSize(GLenum bufferType)
+{
+	if (bufferType == GL_UNIFORM_BUFFER)
+	{
+		static GLint maxUniformBufferSize = 0;
+		if (!maxUniformBufferSize)
+			GL_CALL(glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &maxUniformBufferSize));//65536@1080gtx (65KB)
+		return maxUniformBufferSize;
+	}
+	else if (bufferType == GL_SHADER_STORAGE_BUFFER)
+	{
+		static GLint maxSSBBufferSize = 0;
+		if (!maxSSBBufferSize)
+			GL_CALL(glGetIntegerv(GL_MAX_SHADER_STORAGE_BLOCK_SIZE, &maxSSBBufferSize));//2147483647@1080gtx (2147MB)
+		return maxSSBBufferSize;
+	}
+	else if (bufferType == GL_TRANSFORM_FEEDBACK_BUFFER)
+	{
+		return 0;
+	}
+	else if (bufferType == GL_ATOMIC_COUNTER_BUFFER)
+	{
+		static GLint maxACBufferSize = 0;
+		if (maxACBufferSize <= 0)
+		{
+			GL_CALL(glGetIntegerv(GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE, &maxACBufferSize));//65536@1080gtx (65KB)
+		}
+		return maxACBufferSize;
+	}
+	return 0;
+}
+GLint BufferCore::maxBuffers(GLenum bufferType)
+{
+	if (bufferType == GL_UNIFORM_BUFFER)
+	{
+		static GLint maxUniformBindings = -1;
+		if (maxUniformBindings <= 0)
+		{
+			GL_CALL(glGetIntegerv(GL_MAX_UNIFORM_BUFFER_BINDINGS, &maxUniformBindings));//84@1080gtx
+		}
+		return maxUniformBindings;
+	}
+	else if (bufferType == GL_SHADER_STORAGE_BUFFER)
+	{
+		static GLint maxSSBBindings = -1;
+		if (maxSSBBindings <= 0)
+		{
+			GL_CALL(glGetIntegerv(GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS, &maxSSBBindings));//96@1080gtx
+		}
+		return maxSSBBindings;
+	}
+	else if (bufferType == GL_TRANSFORM_FEEDBACK_BUFFER)
+	{
+		static GLint maxTFBBindings = -1;
+		if (maxTFBBindings <= 0)
+		{
+			GL_CALL(glGetIntegerv(GL_MAX_TRANSFORM_FEEDBACK_BUFFERS, &maxTFBBindings));//4@1080gtx
+			//These are per shader invocation, they work differently to regular bindings
+		}
+		return maxTFBBindings;
+	}
+	else if (bufferType == GL_ATOMIC_COUNTER_BUFFER)
+	{
+		static GLint maxACBindings = -1;
+		if (maxACBindings <= 0)
+		{
+			GL_CALL(glGetIntegerv(GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS, &maxACBindings));//8@1080gtx
+		}
+		return maxACBindings;
+	}
+	return 0;
+}
+
+#include "../ShaderCore.h"
+bool ShaderCore::addBuffer(const char *bufferNameInShader, std::shared_ptr<BufferCore> buffer)
+{//Treat it similar to texture binding points
+	return addBuffer(bufferNameInShader, buffer->getType(), buffer->getBufferBindPoint());
+}

--- a/sdl_exp/visualisation/shader/buffer/BufferCore.h
+++ b/sdl_exp/visualisation/shader/buffer/BufferCore.h
@@ -1,0 +1,93 @@
+#ifndef __Buffer_h__
+#define __Buffer_h__
+#include <GL/glew.h>
+
+/**
+ * This class must be specialised e.g. GL_UNIFORM_BUFFER, GL_SHADER_STORAGE_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER or GL_ATOMIC_COUNTER_BUFFER (not yet implemented the latter two)
+ * Representative of Uniform Buffer Objects
+ * @note GL_TEXTURE_BUFFER are currently treated seperately as the pre-date gl4 buffers and have different binding procedures
+ */
+class BufferCore
+{
+public:
+	/**
+	 * Returns the currently allocated size of the buffer
+	 */
+	size_t getSize() const { return size; }
+	/**
+	 * Returns the GL name of the allocated buffer
+	 * @note This permits you to manually handle the buffer
+	 */
+	GLint getName() const { return bufferName; }
+	/**
+	 * Returns the buffer binding point, this binding point is intended (by sdl_exp) to be unique to all buffers of the same type
+	 * @note glUniformBlockBinding() is used to bind the buffer (via it's binding point) to the shader uniform hosting the buffer
+	 */
+	GLint getBufferBindPoint() const { return bufferBindPoint; }
+	/**
+	 * Returns the GL buffer type, e.g. GL_UNIFORM_BUFFER
+	 */
+	GLenum getType() const { return bufferType; }
+	/*
+	 * Sets the data in the buffer, passing an alternate size can be used to resize the buffer
+	 * @param data Pointer to the data
+	 * @param size The amount of data to store in the buffer, 0 will use the existing size
+	 */
+	void setData(void *data, size_t size=0);
+	/**
+	 * Passes data to a subset of the buffer, denoted by offset
+	 * @note The value of size+offset cannot exceed that returned by getSize()
+	 */
+	void setData(void *data, size_t size, size_t offset);
+	/**
+	 * Copies data out of the texture buffer
+	 * @param dataReturn Pointer to the destination that data will be copied
+	 * @param size The number of bytes to be copied. If 0 this defaults to the size of the buffer
+	 * @param offset The byte offset into the buffer. Defaults to 0
+	 */	
+	void getData(void *dataReturn, size_t size = 0, size_t offset = 0);
+	/**
+	 * Provides read only access to a buffer
+	 * @note unmapBuffer() must be called after access is completed
+	 */
+	void const *mapBufferRead();
+	/**
+	 * Provides write only access to a buffer
+	 * @note unmapBuffer() must be called after access is completed
+	 */
+	void *mapBufferWrite();
+	/**
+	 * Provides read/write access to a buffer
+	 * @note unmapBuffer() must be called after access is completed
+	 */
+	void *mapBufferReadWrite();
+	/**
+	 * Unmaps a buffer
+	 */
+	void unmapBuffer();
+	/**
+	 * Returns the block type of the buffer.
+	 * e.g. GL_SHADER_STORAGE_BLOCK
+	 */
+	GLenum getBlockType();
+
+	static GLint maxSize(GLenum bufferType);
+	static GLint maxBuffers(GLenum bufferType);
+	//Do version for max per shader too, e.g. MAX_COMBINED_UNIFORM_BLOCKS, MAX_COMBINED_SHADER_STORAGE_BLOCKS
+protected:
+	BufferCore(GLenum bufferType, GLint bindPoint, size_t bytes, void* data = nullptr);
+	virtual ~BufferCore();
+private:
+	/**
+	 * Provides access to a buffer
+	 * @param access The access level provided: GL_READ_ONLY, GL_WRITE_ONLY, GL_READ_WRITE
+	 */
+	void *mapBuffer(GLenum access);
+	size_t size;
+	GLuint bufferName;
+protected:
+	const GLuint bufferBindPoint;
+	const GLenum bufferType;
+};
+
+#endif //__UniformBuffer_h__

--- a/sdl_exp/visualisation/shader/buffer/ShaderStorageBuffer.cpp
+++ b/sdl_exp/visualisation/shader/buffer/ShaderStorageBuffer.cpp
@@ -1,0 +1,42 @@
+#define _CRT_SECURE_NO_WARNINGS
+#include "ShaderStorageBuffer.h"
+#include "../../util/GLcheck.h"
+#include <cassert>
+
+std::set<GLint> ShaderStorageBuffer::allocatedBindPoints;
+ShaderStorageBuffer::ShaderStorageBuffer(size_t size, void* data)
+	: BufferCore(GL_SHADER_STORAGE_BUFFER, allocateBindPoint(), size, data)
+{ }
+ShaderStorageBuffer::~ShaderStorageBuffer()
+{
+	allocatedBindPoints.erase(bufferBindPoint);
+}
+
+GLint ShaderStorageBuffer::allocateBindPoint()
+{
+	if (allocatedBindPoints.size() == MaxBuffers())
+	{
+		char buff[1024];
+		sprintf(buff, "Shader Storage Buffer Bindings exceeded!\nLimit = %d\n\nsdl_exp ShaderStorageBuffer objs are not designed for sharing buffer bindings.", MaxBuffers());
+		throw std::exception(buff);
+	}
+	for (unsigned int i = MaxBuffers() - 1; i >= 0; --i)
+	{
+		if (allocatedBindPoints.find(i) == allocatedBindPoints.end())
+		{
+			allocatedBindPoints.insert(i);
+			return i;
+		}
+	}
+	assert(false);//Should never reach here
+	return -1;
+}
+
+GLint ShaderStorageBuffer::MaxSize()
+{
+	return BufferCore::maxSize(GL_SHADER_STORAGE_BUFFER);
+}
+GLint ShaderStorageBuffer::MaxBuffers()
+{
+	return BufferCore::maxBuffers(GL_SHADER_STORAGE_BUFFER);
+}

--- a/sdl_exp/visualisation/shader/buffer/ShaderStorageBuffer.h
+++ b/sdl_exp/visualisation/shader/buffer/ShaderStorageBuffer.h
@@ -1,0 +1,25 @@
+#ifndef __ShaderStorageBuffer_h__
+#define __ShaderStorageBuffer_h__
+#include <GL/glew.h>
+#include <set>
+#include "BufferCore.h"
+/**
+ * Representative of GL_SHADER_STORAGE_BUFFER
+ * These can be used for reading from and writing to during shader execution
+ * Particularly useful for compute shaders
+ * The spec requires a max size of atleast 128mb
+ * Access is however expected to be slower than uniforms, due to the in shader writeable nature
+ */
+class ShaderStorageBuffer : public BufferCore
+{
+public:
+	ShaderStorageBuffer(size_t bytes, void* data = nullptr);
+	~ShaderStorageBuffer();
+	static GLint MaxSize();
+	static GLint MaxBuffers();
+private:
+	GLint allocateBindPoint();
+	static std::set<GLint> allocatedBindPoints;
+};
+
+#endif //__ShaderStorageBuffer_h__

--- a/sdl_exp/visualisation/shader/buffer/UniformBuffer.cpp
+++ b/sdl_exp/visualisation/shader/buffer/UniformBuffer.cpp
@@ -1,0 +1,42 @@
+#define _CRT_SECURE_NO_WARNINGS
+#include "UniformBuffer.h"
+#include "../../util/GLcheck.h"
+#include <cassert>
+
+std::set<GLint> UniformBuffer::allocatedBindPoints;
+UniformBuffer::UniformBuffer(size_t size, void* data)
+	: BufferCore(GL_UNIFORM_BUFFER, allocateBindPoint(), size, data)
+{ }
+UniformBuffer::~UniformBuffer()
+{
+	allocatedBindPoints.erase(bufferBindPoint);
+}
+
+GLint UniformBuffer::allocateBindPoint()
+{
+	if (allocatedBindPoints.size() == MaxBuffers())
+	{
+		char buff[1024];
+		sprintf(buff, "Uniform Buffer Bindings exceeded!\nLimit = %d\n\nsdl_exp UniformBuffer objs are not designed for sharing buffer bindings.", MaxBuffers());
+		throw std::exception(buff);
+	}
+	for (unsigned int i = MaxBuffers() - 1; i >= 0; --i)
+	{
+		if (allocatedBindPoints.find(i) == allocatedBindPoints.end())
+		{
+			allocatedBindPoints.insert(i);
+			return i;
+		}
+	}
+	assert(false);//Should never reach here
+	return -1;
+}
+
+GLint UniformBuffer::MaxSize()
+{
+	return BufferCore::maxSize(GL_UNIFORM_BUFFER);
+}
+GLint UniformBuffer::MaxBuffers()
+{
+	return BufferCore::maxBuffers(GL_UNIFORM_BUFFER);
+}

--- a/sdl_exp/visualisation/shader/buffer/UniformBuffer.h
+++ b/sdl_exp/visualisation/shader/buffer/UniformBuffer.h
@@ -1,0 +1,25 @@
+#ifndef __UniformBuffer_h__
+#define __UniformBuffer_h__
+#include <GL/glew.h>
+#include <set>
+#include "BufferCore.h"
+
+/**
+ * Representative of GL_UNIFORM_BUFFER
+ * These can be used for reading from during shader execution
+ * Particularly useful for passing light/material info or arrays of transformation matrices
+ * The spec requires a max size of atleast 16KB (likely much bigger, e.g. 65KB on modern NV hardware)
+ */
+class UniformBuffer : public BufferCore
+{
+public:
+	UniformBuffer(size_t bytes, void* data = nullptr);
+	~UniformBuffer();
+	static GLint MaxSize();
+	static GLint MaxBuffers();
+private:
+	GLint allocateBindPoint();
+	static std::set<GLint> allocatedBindPoints;
+};
+
+#endif //__UniformBuffer_h__


### PR DESCRIPTION
Each buffer has a unique bind point. Therefore you can have a maximum of ~84 uniform buffers and 96 shader storage buffers. This seems like enough for normal use cases, if you need more you will need to make some kind of shared bind point version. However at this time I decided to keep `Shaders` involvement separate to that of the Buffer classes.

Currently only Uniform and ShaderStorage are supported, should be possible to add AtomicCounter, TransformFeedback in future if necessary.